### PR TITLE
Attach persistent disk to VM & fix persistent space initialization

### DIFF
--- a/jobs/dummy/templates/ctl.erb
+++ b/jobs/dummy/templates/ctl.erb
@@ -18,11 +18,12 @@ exec 2>> $LOG_DIR/$JOB_NAME.stderr.log
 case $1 in
 
   start)
-    mkdir -p $RUN_DIR $LOG_DIR $EPHEMERAL
+    mkdir -p $RUN_DIR $LOG_DIR $EPHEMERAL $PERSISTENT
     chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $EPHEMERAL $PERSISTENT
 
     ## Start Code Here
     echo 1 >> $PIDFILE
+    su vcap -c "echo 'Hello world' >> $PERSISTENT/hello.txt"
 
     ;;
 

--- a/templates/dummy.yml
+++ b/templates/dummy.yml
@@ -17,6 +17,7 @@ stemcells:
 instance_groups:
 - name: dummy
   instances: 1
+  persistent_disk: 1024
   vm_type: tiny
   stemcell: ubuntu
   networks:


### PR DESCRIPTION
The job dummy fails to execute because the dir /var/vcap/store does not exist. In fact, no persistent disk is attached to the VM in the template "dummy.yml". Moreover, the job dummy does not initialize the dir /var/vcap/store when it starts.

This PR adds a persistent disk to the VM, and also creates the dir /var/vcap/store/dummy when the job dummy is running.